### PR TITLE
build: use latest vrs-python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # VRSAnnotator
 
 ### Description
-GA4GH VRS identifiers provide a standardized way to represent genomic variations, making it easier to exchange, harmonize, and integrate genomic information. 
+GA4GH VRS identifiers provide a standardized way to represent genomic variations, making it easier to exchange, harmonize, and integrate genomic information.
 
 This WDL workflow wraps the functionality of vrs-python's [vcf_annotator](https://github.com/ga4gh/vrs-python/blob/main/docs/extras/vcf_annotator.md), allowing you to annotate Variant Call Format (VCF) files with GA4GH Variation Representation Specification (VRS) Allele IDs on Terra! This makes integration of genomic variant data with downstream evidence data like [MetaKB](https://search.cancervariants.org/) much easier.
 
@@ -12,13 +12,13 @@ To get started, navigate to the [VRS AnVIL](https://app.terra.bio/#workspaces/te
 - `output_vcf_name` (String): Name of annotated VCF file with its file extension (vcf.gz)
 - `seqrepo_tarball` (File, optional): Google resource path for seqrepo tarball (tar.gz). Defaults to tarball stored in the requestor pays VRS AnVIL Workspace.
 - `compute_for_ref` (boolean, optional): Whether to compute both the ref and alt allele or compute only the alt allele for each variant. Defaults to true, computing both.
-- `vrs_attributes` (boolean, optional): Whether to compute both the ref and alt allele or compute only the alt allele for each variant. Defaults to true, computing both.
+- `compute_vrs_attributes` (boolean, optional): Whether to compute both the ref and alt allele or compute only the alt allele for each variant. Defaults to true, computing both.
 - `genome_assembly` (String, optional): genome assembly or genome build used by the VCF. Defaults to "GRCh38", but "GRCh37" is also supported.
 
 
 ## Outputs
 To write output file paths to directly to a Terra data table, specify the outputs, specifically:
-- `output_vcf` (File): column in a Terra data table to write the output VCF to
-- `output_vcf_index` (File): column in a Terra data table to write the tabix output VCF index to
+- `annotated_vcf` (File): column in a Terra data table to write the output VCF to
+- `annotated_vcf_index` (File): column in a Terra data table to write the tabix output VCF index to
 
 For more info on how to write workflow ouputs to the data table, see the [Terra docs](https://support.terra.bio/hc/en-us/articles/4500420806299-Writing-workflow-outputs-to-the-data-table)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To get started, navigate to the [VRS AnVIL](https://app.terra.bio/#workspaces/te
 - `compute_for_ref` (boolean, optional): Whether to compute both the ref and alt allele or compute only the alt allele for each variant. Defaults to true, computing both.
 - `compute_vrs_attributes` (boolean, optional): Whether to include VRS Allele start, end, and state or compute only VRS ID for each variant. Defaults to true, computing both.
 - `genome_assembly` (String, optional): genome assembly or genome build used by the VCF. Defaults to "GRCh38", but "GRCh37" is also supported.
+- `memory` (Int, optional): Memory allocated to the instance. Defaults to 8GB. Cost is scaled to memory, so for most jobs, the performance-to-cost ratio  will be most effective around 8GB.
 
 
 ## Outputs

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -10,6 +10,15 @@ RUN cd ~ && \
     make install && \
     export BCFTOOLS_PLUGINS=~/bcftools/plugins/
 
+# get tabix
+RUN cd ~/htslib && \
+    autoheader && \
+    autoconf && \
+    ./configure prefix=$HOME && \
+    make && \
+    make install
+
+
 RUN pip install ga4gh.vrs[extras]~=2.0.1 biocommons.seqrepo
 
 RUN sudo apt-get update && sudo apt-get install -y rsync

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -19,9 +19,10 @@ RUN cd ~/htslib && \
     make install
 
 
-RUN pip install ga4gh.vrs[extras]@git+https://github.com/ga4gh/vrs-python.git@vcf-collection-memory && \
+RUN pip install ga4gh.vrs[extras]~=2.1.0 && \
     pip install biocommons.seqrepo
 
-RUN sudo apt-get update && sudo apt-get install -y rsync
+RUN sudo apt-get update && \
+    sudo apt-get install -y rsync
 
 CMD ["/bin/bash"]

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -10,15 +10,6 @@ RUN cd ~ && \
     make install && \
     export BCFTOOLS_PLUGINS=~/bcftools/plugins/
 
-# get tabix
-RUN cd ~/htslib && \
-    autoheader && \
-    autoconf && \
-    ./configure prefix=$HOME && \
-    make && \
-    make install
-
-
 RUN pip install ga4gh.vrs[extras]~=2.1.0 && \
     pip install biocommons.seqrepo
 

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -19,7 +19,8 @@ RUN cd ~/htslib && \
     make install
 
 
-RUN pip install ga4gh.vrs[extras]~=2.0.1 biocommons.seqrepo
+RUN pip install ga4gh.vrs[extras]@git+https://github.com/ga4gh/vrs-python.git@vcf-collection-memory && \
+    pip install biocommons.seqrepo
 
 RUN sudo apt-get update && sudo apt-get install -y rsync
 

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -10,7 +10,7 @@ RUN cd ~ && \
     make install && \
     export BCFTOOLS_PLUGINS=~/bcftools/plugins/
 
-RUN pip install ga4gh.vrs[extras]==2.0.0a12 biocommons.seqrepo
+RUN pip install ga4gh.vrs[extras]~=2.0.0 setuptools pysam>=0.23.0 biocommons.seqrepo
 
 RUN sudo apt-get update && sudo apt-get install -y rsync
 

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -10,7 +10,7 @@ RUN cd ~ && \
     make install && \
     export BCFTOOLS_PLUGINS=~/bcftools/plugins/
 
-RUN pip install ga4gh.vrs[extras]==2.0.0a7 biocommons.seqrepo
+RUN pip install ga4gh.vrs[extras]==2.0.0a12 biocommons.seqrepo
 
 RUN sudo apt-get update && sudo apt-get install -y rsync
 

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -10,7 +10,7 @@ RUN cd ~ && \
     make install && \
     export BCFTOOLS_PLUGINS=~/bcftools/plugins/
 
-RUN pip install ga4gh.vrs[extras]~=2.0.0 setuptools pysam>=0.23.0 biocommons.seqrepo
+RUN pip install ga4gh.vrs[extras]~=2.0.1 biocommons.seqrepo
 
 RUN sudo apt-get update && sudo apt-get install -y rsync
 

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -40,7 +40,7 @@ task annotate {
     Int disk_size = ceil(size(input_vcf_path, "GB") + size(seqrepo_tarball, "GB") + 10)
 
     runtime {
-        docker: "quay.io/ohsu-comp-bio/vrs-annotator:base"
+        docker: "quay.io/ohsu-comp-bio/vrs-annotator:vrs-2.0"
         disks: "local-disk " + disk_size + " SSD"
         bootDiskSizeGb: disk_size
         memory: "8G"
@@ -81,8 +81,8 @@ task annotate {
 
         # annotate and index vcf
         vrs-annotate vcf ~{input_vcf_path} \
-            --vcf_out ~{output_vcf_name} \
-            --dataproxy-uri $SEQREPO_DIR/latest \
+            --vcf-out ~{output_vcf_name} \
+            --dataproxy-uri seqrepo+file://$SEQREPO_DIR/latest \
             --assembly ~{genome_assembly} \
             $REF_FLAG \
             $VRS_ATTRIBUTES_FLAG

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -4,7 +4,7 @@ version 1.0
 workflow VRSAnnotator {
     input {
         File input_vcf_path
-        String output_vcf_name 
+        String output_vcf_name
         File seqrepo_tarball
         Boolean compute_for_ref = true
         Boolean compute_vrs_attributes = true
@@ -72,7 +72,7 @@ task annotate {
         else
             REF_FLAG="--skip_ref"
         fi
-        
+
         if ~{compute_vrs_attributes}; then
             VRS_ATTRIBUTES_FLAG="--vrs_attributes"
         else
@@ -80,14 +80,13 @@ task annotate {
         fi
 
         # annotate and index vcf
-        python -m ga4gh.vrs.extras.vcf_annotation \
-            --vcf_in ~{input_vcf_path} \
+        vrs-annotate vcf ~{input_vcf_path} \
             --vcf_out ~{output_vcf_name} \
             --seqrepo_root_dir $SEQREPO_DIR/latest \
             --assembly ~{genome_assembly} \
             $REF_FLAG \
             $VRS_ATTRIBUTES_FLAG
-        
+
         bcftools index -t ~{output_vcf_name}
     >>>
 

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -9,7 +9,7 @@ workflow VRSAnnotator {
         Boolean compute_for_ref = true
         Boolean compute_vrs_attributes = true
         String genome_assembly = "GRCh38"
-        Int memory_in_gb = 16
+        Int memory_in_gb = 8
     }
 
     call annotate {
@@ -37,7 +37,7 @@ task annotate {
         Boolean compute_for_ref
         Boolean compute_vrs_attributes
         String genome_assembly
-        Int memory_in_gb = 16
+        Int memory_in_gb = 8
     }
 
     Int disk_size = ceil(4*size(input_vcf_path, "GB") + 2*size(seqrepo_tarball, "GB") + 20)

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -37,7 +37,7 @@ task annotate {
         String genome_assembly
     }
 
-    Int disk_size = ceil(size(input_vcf_path, "GB") + size(seqrepo_tarball, "GB") + 10)
+    Int disk_size = 3*ceil(size(input_vcf_path, "GB") + size(seqrepo_tarball, "GB") + 20)
 
     runtime {
         docker: "quay.io/ohsu-comp-bio/vrs-annotator:vrs-2.0"

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -40,7 +40,7 @@ task annotate {
     Int disk_size = ceil(3*size(input_vcf_path, "GB") + size(seqrepo_tarball, "GB") + 20)
 
     runtime {
-        docker: "quay.io/ohsu-comp-bio/vrs-annotator:vrs-2.0"
+        docker: "quay.io/ohsu-comp-bio/vrs-annotator:vrs-2.0_oom_fix"
         disks: "local-disk " + disk_size + " SSD"
         bootDiskSizeGb: disk_size
         memory: "16G"

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -37,7 +37,7 @@ task annotate {
         String genome_assembly
     }
 
-    Int disk_size = ceil(3*size(input_vcf_path, "GB") + size(seqrepo_tarball, "GB") + 20)
+    Int disk_size = ceil(4*size(input_vcf_path, "GB") + 2*size(seqrepo_tarball, "GB") + 20)
 
     runtime {
         docker: "quay.io/ohsu-comp-bio/vrs-annotator:vrs-2.0_oom_fix"

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -52,6 +52,7 @@ task annotate {
         if [[ ~{input_vcf_path} == *.gz ]]; then
             echo "creating index for input VCF"
             sudo chown "$(whoami)" ~{input_vcf_path}
+            sudo chmod 644 ~{input_vcf_path}
             bcftools index -t ~{input_vcf_path}
         fi
 

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -70,11 +70,11 @@ task annotate {
         if ~{compute_for_ref}; then
             REF_FLAG=""
         else
-            REF_FLAG="--skip_ref"
+            REF_FLAG="--skip-ref"
         fi
 
         if ~{compute_vrs_attributes}; then
-            VRS_ATTRIBUTES_FLAG="--vrs_attributes"
+            VRS_ATTRIBUTES_FLAG="--vrs-attributes"
         else
             VRS_ATTRIBUTES_FLAG=""
         fi
@@ -82,7 +82,7 @@ task annotate {
         # annotate and index vcf
         vrs-annotate vcf ~{input_vcf_path} \
             --vcf_out ~{output_vcf_name} \
-            --seqrepo_root_dir $SEQREPO_DIR/latest \
+            --dataproxy-uri $SEQREPO_DIR/latest \
             --assembly ~{genome_assembly} \
             $REF_FLAG \
             $VRS_ATTRIBUTES_FLAG

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -67,9 +67,12 @@ task annotate {
         seqrepo --root-directory $SEQREPO_DIR update-latest
 
         # change permissions on vcf path
-        echo user: $USER
+        echo user: $(whoami)
+        ls -l $SEQREPO_DIR
         ls -l ~{input_vcf_path}
         sudo chown "$(whoami)" ~{input_vcf_path}
+        sudo chmod 644
+        ls -l ~{input_vcf_path}
 
         # add runtime flags
         if ~{compute_for_ref}; then

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -51,6 +51,7 @@ task annotate {
         # if compressed input VCF, create index
         if [[ ~{input_vcf_path} == *.gz ]]; then
             echo "creating index for input VCF"
+            sudo chown "$(whoami)" ~{input_vcf_path}
             bcftools index -t ~{input_vcf_path}
         fi
 
@@ -66,14 +67,6 @@ task annotate {
         sudo tar -xzf ~{seqrepo_tarball} --directory=$HOME
         sudo chown "$(whoami)" $SEQREPO_DIR
         seqrepo --root-directory $SEQREPO_DIR update-latest
-
-        # change permissions on vcf path
-        echo user: $(whoami)
-        ls -l $SEQREPO_DIR
-        ls -l ~{input_vcf_path}
-        sudo chown "$(whoami)" ~{input_vcf_path}
-        sudo chmod 644
-        ls -l ~{input_vcf_path}
 
         # add runtime flags
         if ~{compute_for_ref}; then

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -44,6 +44,7 @@ task annotate {
         disks: "local-disk " + disk_size + " SSD"
         bootDiskSizeGb: disk_size
         memory: "16G"
+        preemptible: 0
     }
 
     command <<<

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -66,6 +66,11 @@ task annotate {
         sudo chown "$(whoami)" $SEQREPO_DIR
         seqrepo --root-directory $SEQREPO_DIR update-latest
 
+        # change permissions on vcf path
+        echo user: $USER
+        ls -l ~{input_vcf_path}
+        sudo chown "$(whoami)" ~{input_vcf_path}
+
         # add runtime flags
         if ~{compute_for_ref}; then
             REF_FLAG=""

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -40,7 +40,7 @@ task annotate {
     Int disk_size = ceil(3*size(input_vcf_path, "GB") + size(seqrepo_tarball, "GB") + 20)
 
     runtime {
-        docker: "quay.io/ohsu-comp-bio/vrs-annotator:vrs-2.0"
+        docker: "quay.io/ohsu-comp-bio/vrs-annotator:vrs-2.0_tabix"
         disks: "local-disk " + disk_size + " SSD"
         bootDiskSizeGb: disk_size
         memory: "16G"
@@ -52,8 +52,9 @@ task annotate {
         if [[ ~{input_vcf_path} == *.gz ]]; then
             echo "creating index for input VCF"
             sudo chown "$(whoami)" ~{input_vcf_path}
-            sudo chmod 644 ~{input_vcf_path}
-            bcftools index -t ~{input_vcf_path}
+            # sudo chmod 644 ~{input_vcf_path}
+            tabix -p vcf ~{input_vcf_path}
+            # bcftools index -t ~{input_vcf_path}
         fi
 
         # setup seqrepo

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -37,7 +37,7 @@ task annotate {
         String genome_assembly
     }
 
-    Int disk_size = 3*ceil(size(input_vcf_path, "GB") + size(seqrepo_tarball, "GB") + 20)
+    Int disk_size = ceil(3*size(input_vcf_path, "GB") + size(seqrepo_tarball, "GB") + 20)
 
     runtime {
         docker: "quay.io/ohsu-comp-bio/vrs-annotator:vrs-2.0"

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -43,7 +43,7 @@ task annotate {
         docker: "quay.io/ohsu-comp-bio/vrs-annotator:vrs-2.0"
         disks: "local-disk " + disk_size + " SSD"
         bootDiskSizeGb: disk_size
-        memory: "8G"
+        memory: "16G"
     }
 
     command <<<

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -40,11 +40,10 @@ task annotate {
     Int disk_size = ceil(4*size(input_vcf_path, "GB") + 2*size(seqrepo_tarball, "GB") + 20)
 
     runtime {
-        docker: "quay.io/ohsu-comp-bio/vrs-annotator:vrs-2.0_oom_fix"
+        docker: "quay.io/ohsu-comp-bio/vrs-annotator:vrs-2.0"
         disks: "local-disk " + disk_size + " SSD"
         bootDiskSizeGb: disk_size
         memory: "16G"
-        preemptible: 0
     }
 
     command <<<

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -43,7 +43,7 @@ task annotate {
     Int disk_size = ceil(4*size(input_vcf_path, "GB") + 2*size(seqrepo_tarball, "GB") + 20)
 
     runtime {
-        docker: "quay.io/ohsu-comp-bio/vrs-annotator:vrs-2.0"
+        docker: "quay.io/ohsu-comp-bio/vrs-annotator:vrs-2.1.0"
         disks: "local-disk " + disk_size + " SSD"
         bootDiskSizeGb: disk_size
         memory: memory_in_gb + "G"

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -40,7 +40,7 @@ task annotate {
     Int disk_size = ceil(3*size(input_vcf_path, "GB") + size(seqrepo_tarball, "GB") + 20)
 
     runtime {
-        docker: "quay.io/ohsu-comp-bio/vrs-annotator:vrs-2.0_tabix"
+        docker: "quay.io/ohsu-comp-bio/vrs-annotator:vrs-2.0"
         disks: "local-disk " + disk_size + " SSD"
         bootDiskSizeGb: disk_size
         memory: "16G"
@@ -51,10 +51,7 @@ task annotate {
         # if compressed input VCF, create index
         if [[ ~{input_vcf_path} == *.gz ]]; then
             echo "creating index for input VCF"
-            sudo chown "$(whoami)" ~{input_vcf_path}
-            # sudo chmod 644 ~{input_vcf_path}
-            tabix -p vcf ~{input_vcf_path}
-            # bcftools index -t ~{input_vcf_path}
+            bcftools index -t ~{input_vcf_path}
         fi
 
         # setup seqrepo

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -9,6 +9,7 @@ workflow VRSAnnotator {
         Boolean compute_for_ref = true
         Boolean compute_vrs_attributes = true
         String genome_assembly = "GRCh38"
+        Int memory_in_gb = 16
     }
 
     call annotate {
@@ -18,7 +19,8 @@ workflow VRSAnnotator {
             seqrepo_tarball = seqrepo_tarball,
             compute_for_ref = compute_for_ref,
             compute_vrs_attributes = compute_vrs_attributes,
-            genome_assembly = genome_assembly
+            genome_assembly = genome_assembly,
+            memory_in_gb = memory_in_gb
     }
 
     output {
@@ -35,6 +37,7 @@ task annotate {
         Boolean compute_for_ref
         Boolean compute_vrs_attributes
         String genome_assembly
+        Int memory_in_gb = 16
     }
 
     Int disk_size = ceil(4*size(input_vcf_path, "GB") + 2*size(seqrepo_tarball, "GB") + 20)
@@ -43,7 +46,7 @@ task annotate {
         docker: "quay.io/ohsu-comp-bio/vrs-annotator:vrs-2.0"
         disks: "local-disk " + disk_size + " SSD"
         bootDiskSizeGb: disk_size
-        memory: "16G"
+        memory: memory_in_gb + "G"
     }
 
     command <<<


### PR DESCRIPTION
* use latest VRS-Python version. Shouldn't significantly impact things but it does include some better internal logging code, which could be helpful for handling errors. 
* double-check a couple param names in the README. pretty immaterial.